### PR TITLE
[ISS] feat: implement endpoints 2.1.1, 2.6.2, 2.7, 2.8, 2.9.2; closes #45

### DIFF
--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/controller/PublicController.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/controller/PublicController.java
@@ -1,0 +1,21 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.controller;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response.VehicleStatusDTO;
+
+public class PublicController {
+    
+    // 2.1.1 Display info for unregistered users
+    @GetMapping("/vehicles")
+    public ResponseEntity<List<VehicleStatusDTO>> getActiveVehicles() {
+        List<VehicleStatusDTO> vehicles = Arrays.asList(
+                new VehicleStatusDTO("Car1", "STANDARD", true, "Location1"),
+                new VehicleStatusDTO("Car2", "LUX", false, "Location2"));
+        return ResponseEntity.ok(vehicles);
+    }
+}

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/request/InconsistencyReportRequestDTO.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/request/InconsistencyReportRequestDTO.java
@@ -1,0 +1,13 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InconsistencyReportRequestDTO {
+    private String passengerEmail;
+    private String location;
+    private String message;
+    private String timestamp;
+}

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/request/RideRatingRequestDTO.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/request/RideRatingRequestDTO.java
@@ -1,0 +1,12 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RideRatingRequestDTO {
+    private Integer driverRating;
+    private Integer vehicleRating;
+    private String comment;
+}

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/InconsistencyReportResponseDTO.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/InconsistencyReportResponseDTO.java
@@ -1,0 +1,16 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class InconsistencyReportResponseDTO {
+    private Long rideId;
+    private String passengerEmail;
+    private String location;
+    private String message;
+    private String statusMessage;
+}

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/RideRatingResponseDTO.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/RideRatingResponseDTO.java
@@ -1,0 +1,14 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RideRatingResponseDTO {
+    private Long rideId;
+    private String status;
+    private String message;
+}

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/RideTrackingDTO.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/RideTrackingDTO.java
@@ -1,0 +1,15 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RideTrackingDTO {
+    private Long rideId;
+    private String vehicleLocation;
+    private String estimatedArrivalTime;
+    private String status;
+}

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/VehicleStatusDTO.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/VehicleStatusDTO.java
@@ -1,0 +1,15 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class VehicleStatusDTO {
+    private String name;
+    private String type;
+    private Boolean available;
+    private String location;
+}


### PR DESCRIPTION
feat: implement ride-related endpoints for Student2 responsibilities

Implemented public vehicle overview endpoint (2.1.1) for unregistered users
Added ride tracking during active rides with live ETA updates (2.6.2)
Implemented inconsistency reporting mechanism for passengers during rides (2.6.2)
Added ride completion endpoint for drivers with price and duration calculation (2.7)
Implemented ride, driver, and vehicle rating with 3-day deadline validation (2.8)
Added driver ride history endpoint with sorting and optional date filtering (2.9.2)
Mock data is used to enable easy testing and validation of all endpoints

closes #45