### PR TITLE
[IKS] Connect registration form to backend with auto-login

### DIFF
--- a/IKS/src/app/forms/register/register.ts
+++ b/IKS/src/app/forms/register/register.ts
@@ -78,16 +78,32 @@ export class Register {
       password: this.registerForm.value.password,
       phoneNumber: this.registerForm.value.phoneNumber,
       city: this.registerForm.value.address,
-      userType: 'REGISTERED_USER'
+      userType: 'REGISTERED_USER',
+      profilePhoto: this.photoPreview || undefined // Base64 string or undefined if no photo
     };
 
     this.authService.register(registerData).subscribe({
       next: (response) => {
-        this.isLoading = false;
-        this.snackBar.open(response.message + ' You can now log in.', 'Close', { duration: 4000 });
-        setTimeout(() => {
-          this.router.navigate(['/login']);
-        }, 1500);
+        this.snackBar.open(response.message + ' Logging you in...', 'Close', { duration: 2000 });
+        
+        // Automatically log in the user after successful registration
+        const loginCredentials = {
+          email: this.registerForm.value.email,
+          password: this.registerForm.value.password
+        };
+
+        this.authService.login(loginCredentials).subscribe({
+          next: (loginResponse) => {
+            this.isLoading = false;
+            this.snackBar.open('Welcome! Registration successful.', 'Close', { duration: 3000 });
+            this.router.navigate(['/user-profile']);
+          },
+          error: (loginError) => {
+            this.isLoading = false;
+            this.snackBar.open('Registration successful! Please log in.', 'Close', { duration: 3000 });
+            this.router.navigate(['/login']);
+          }
+        });
       },
       error: (error) => {
         this.isLoading = false;

--- a/IKS/src/app/models/auth.models.ts
+++ b/IKS/src/app/models/auth.models.ts
@@ -12,6 +12,7 @@ export interface RegisterRequest {
   phoneNumber: string;
   city: string;
   userType: string; // "REGISTERED_USER"
+  profilePhoto?: string; // Base64 string, optional
 }
 
 // Response DTOs


### PR DESCRIPTION
## Changes
- Connected registration form to backend API endpoint (`/api/auth/register`)
- Implemented automatic login after successful registration
- User is now redirected directly to their profile page without needing to log in manually
- Added proper error handling and user feedback with Material snackbar notifications

### Testing
- Registration tested via Postman - backend endpoint working correctly
- Frontend form successfully registers new users
- Auto-login after registration working
- User is redirected to profile page immediately after registration
- Error messages display correctly for validation failures

Closes #66 