### PR TITLE
Add Favorite Routes Management for Quick Ride Booking

### DIFF
--- a/IKS/src/app/models/ride-dto.model.ts
+++ b/IKS/src/app/models/ride-dto.model.ts
@@ -4,6 +4,15 @@ export interface LocationDTO {
   longitude: number;
 }
 
+export interface FavoriteRouteDTO {
+  routeId: number;
+  startLocation: string;
+  endLocation: string;
+  intermediateStops: string[];
+  distanceKm: number;
+  estimatedTimeMin: number;
+}
+
 export interface RideRequestDTO {
   locations: LocationDTO[];
   passengerEmails: string[];
@@ -29,6 +38,7 @@ export interface RideCreatedResponseDTO {
 
 export interface RideHistoryDTO {
   id: number;
+  routeId?: number;
   passengerEmail: string;
   driverEmail: string;
   startLocation: string;

--- a/IKS/src/app/ride-booking/ride-booking.css
+++ b/IKS/src/app/ride-booking/ride-booking.css
@@ -387,3 +387,33 @@ app-map {
   margin-top: 20px;
   cursor: pointer;
 }
+
+/* NO FAVORITES MESSAGE */
+.no-favorites {
+  padding: 20px;
+  text-align: center;
+  color: #a098ae;
+  font-size: 0.85rem;
+  font-style: italic;
+  margin: 10px 0;
+}
+
+/* STOPS INFO */
+.stops-info {
+  font-size: 0.75rem;
+  color: #a098ae;
+  display: block;
+  margin-top: 4px;
+}
+
+.route-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dist {
+  font-size: 0.7rem;
+  color: #FFD524;
+  font-weight: 600;
+}

--- a/IKS/src/app/ride-booking/ride-booking.html
+++ b/IKS/src/app/ride-booking/ride-booking.html
@@ -10,13 +10,14 @@
     </div>
 
     <div class="scroll-content">
+      <!-- FORMA ZA LOKACIJE - UVEK VIDLJIVA -->
       <div class="section-container">
         <div class="input-group">
           <span class="dot outline">S</span>
           <input type="text" [(ngModel)]="startLocation" placeholder="Add starting location">
         </div>
 
-       <div class="input-group" *ngFor="let stop of intermediateStops; let i = index; trackBy: trackByIndex">
+        <div class="input-group" *ngFor="let stop of intermediateStops; let i = index; trackBy: trackByIndex">
           <span class="dot outline">S{{i + 1}}</span>
           <input type="text" [(ngModel)]="intermediateStops[i]" placeholder="Add stop">
           <button class="remove-stop" (click)="removeStop(i)">&times;</button>
@@ -35,6 +36,7 @@
 
       <hr class="separator">
 
+      <!-- KALENDAR I VREME -->
       <div class="date-time-flex-row">
         <div class="date-section">
           <label class="section-label">Choose date</label>
@@ -57,41 +59,52 @@
         <div class="time-section">
           <label class="section-label">Enter time</label>
           <div class="stepper-time-picker">
-  <div class="time-unit">
-    <button class="minus-btn" (click)="decrementHour()">−</button>
-    <span class="time-val">{{formatTime(hourValue)}}</span>
-    <button class="plus-btn" (click)="incrementHour()">+</button>
-  </div>
-  <span class="time-sep">:</span>
-  <div class="time-unit">
-    <button class="minus-btn" (click)="decrementMinute()">−</button>
-    <span class="time-val">{{formatTime(minuteValue)}}</span>
-    <button class="plus-btn" (click)="incrementMinute()">+</button>
-  </div>
-</div>
-        </div>
-      </div>
-
-      <hr class="separator">
-
-      <div class="section-container">
-        <div class="accordion-header" (click)="toggleFavorites()">
-          <span>Select from Favorite Routes</span>
-          <span class="arrow" [class.open]="showFavorites">▼</span>
-        </div>
-        <div class="accordion-content" *ngIf="showFavorites">
-          <div class="fav-route-card" *ngFor="let i of [1,2,3]">
-            <div class="route-info">
-              <span class="dist">Distance 8.2km</span>
-              <p>Stražilovska → Bulevar Kralja Petra I</p>
+            <div class="time-unit">
+              <button class="minus-btn" (click)="decrementHour()">−</button>
+              <span class="time-val">{{formatTime(hourValue)}}</span>
+              <button class="plus-btn" (click)="incrementHour()">+</button>
             </div>
-            <button class="yellow-btn-small">Choose</button>
+            <span class="time-sep">:</span>
+            <div class="time-unit">
+              <button class="minus-btn" (click)="decrementMinute()">−</button>
+              <span class="time-val">{{formatTime(minuteValue)}}</span>
+              <button class="plus-btn" (click)="incrementMinute()">+</button>
+            </div>
           </div>
         </div>
       </div>
 
       <hr class="separator">
 
+      <!-- OMILJENE RUTE - ACCORDION -->
+      <div class="section-container">
+        <div class="accordion-header" (click)="toggleFavorites()">
+          <span>Select from Favorite Routes</span>
+          <span class="arrow" [class.open]="showFavorites">▼</span>
+        </div>
+        <div class="accordion-content" *ngIf="showFavorites">
+          @if (favoriteRoutes.length === 0) {
+            <p class="no-favorites">No favorite routes yet. Add routes from your ride history!</p>
+          }
+          
+          @for (route of favoriteRoutes; track route.routeId) {
+            <div class="fav-route-card">
+              <div class="route-info">
+                <span class="dist">Distance {{ route.distanceKm.toFixed(1) }}km · {{ route.estimatedTimeMin.toFixed(0) }} min</span>
+                <p>{{ route.startLocation }} → {{ route.endLocation }}</p>
+                @if (route.intermediateStops.length > 0) {
+                  <span class="stops-info">{{ route.intermediateStops.length }} stop(s): {{ route.intermediateStops.join(', ') }}</span>
+                }
+              </div>
+              <button class="yellow-btn-small" (click)="selectFavoriteRoute(route)">Choose</button>
+            </div>
+          }
+        </div>
+      </div>
+
+      <hr class="separator">
+
+      <!-- PUTNICI -->
       <div class="section-container">
         <label class="section-label">Invite passengers</label>
         <div class="input-group">
@@ -110,6 +123,7 @@
 
       <hr class="separator">
 
+      <!-- TIP VOZILA -->
       <div class="section-container">
         <label class="section-label">Vehicle Type</label>
         <div class="vehicle-type-grid">

--- a/IKS/src/app/ride-booking/ride-booking.ts
+++ b/IKS/src/app/ride-booking/ride-booking.ts
@@ -5,7 +5,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { HttpClientModule } from '@angular/common/http';
 import { RideService } from '../rides/services/ride.service';
-import { RideCreatedResponseDTO, RideRequestDTO } from '../models/ride-dto.model';
+import { RouteService } from '../services/route.service'; // DODAJ
+import { RideCreatedResponseDTO, RideRequestDTO, FavoriteRouteDTO } from '../models/ride-dto.model'; // DODAJ FavoriteRouteDTO
 import { GeocodingService } from '../services/geocoding.service';
 import { forkJoin } from 'rxjs';
 
@@ -40,11 +41,56 @@ export class RideBooking implements OnInit {
   hourValue: number = 12;
   minuteValue: number = 0;
 
-  constructor(private rideService: RideService, private geocodingService: GeocodingService, private cdr: ChangeDetectorRef) {}
+  // DODAJ
+  favoriteRoutes: FavoriteRouteDTO[] = [];
+
+  constructor(
+    private rideService: RideService, 
+    private routeService: RouteService, // DODAJ
+    private geocodingService: GeocodingService, 
+    private cdr: ChangeDetectorRef
+  ) {}
 
   ngOnInit() {
     this.generateCalendar();
+    this.loadFavoriteRoutes(); // DODAJ
   }
+
+  // NOVA METODA
+  loadFavoriteRoutes() {
+    this.routeService.getFavoriteRoutes().subscribe({
+      next: (routes) => {
+        this.favoriteRoutes = routes;
+        this.cdr.detectChanges();
+      },
+      error: (err) => {
+        console.error('Error loading favorite routes:', err);
+        this.favoriteRoutes = [];
+      }
+    });
+  }
+
+  // NOVA METODA
+  selectFavoriteRoute(route: FavoriteRouteDTO) {
+  // Popuni start location
+  this.startLocation = route.startLocation;
+  
+  // Popuni end location
+  this.endLocation = route.endLocation;
+  
+  // Popuni intermediate stops
+  if (route.intermediateStops && route.intermediateStops.length > 0) {
+    this.intermediateStops = [...route.intermediateStops];
+  } else {
+    this.intermediateStops = [''];
+  }
+  
+  // Zatvori accordion
+  this.showFavorites = false;
+  
+  // Force UI update
+  this.cdr.detectChanges();
+}
 
   requestRide() {
     if (!this.startLocation || !this.startLocation.trim()) {
@@ -138,8 +184,8 @@ ${validEmails.length > 0 ? '👥 Passengers: ' + validEmails.join(', ') : ''}
             `.trim();
             
             alert(message);
-this.resetForm();
-this.cdr.detectChanges();
+            this.resetForm();
+            this.cdr.detectChanges();
           },
           error: (err) => {
             console.error('Error creating ride:', err);
@@ -196,9 +242,10 @@ this.cdr.detectChanges();
   decrementHour() { this.hourValue = this.hourValue === 0 ? 23 : this.hourValue - 1; }
   decrementMinute() { this.minuteValue = this.minuteValue === 0 ? 59 : this.minuteValue - 1; }
 
-trackByIndex(index: number): number {
-  return index;
-}
+  trackByIndex(index: number): number {
+    return index;
+  }
+  
   formatTime(val: number): string { return val.toString().padStart(2, '0'); }
 
   generateCalendar() {

--- a/IKS/src/app/rides/ride-history/user-ride-history/user-ride-history.css
+++ b/IKS/src/app/rides/ride-history/user-ride-history/user-ride-history.css
@@ -582,6 +582,42 @@ mat-card.ride-card.selected,
   transform: translateY(-1px);
 }
 
+/* FAVORITE BUTTON */
+.favorite-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 50%;
+  transition: all 0.3s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.favorite-btn mat-icon {
+  color: #a098ae;
+  font-size: 24px;
+  width: 24px;
+  height: 24px;
+  transition: all 0.3s;
+}
+
+.favorite-btn:hover mat-icon {
+  color: #FFD524;
+  transform: scale(1.1);
+}
+
+.favorite-btn.favorite-active mat-icon {
+  color: #FFD524;
+}
+
+.ride-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px; /* SMANJI GAP jer sad ima zvezdicu */
+}
+
 /* Responsive Design */
 @media (max-width: 1200px) {
   .details-sidebar.open {

--- a/IKS/src/app/rides/ride-history/user-ride-history/user-ride-history.html
+++ b/IKS/src/app/rides/ride-history/user-ride-history/user-ride-history.html
@@ -51,31 +51,39 @@
         </div>
 
         @for (ride of getRidesByDate(date); track ride.id) {
-          <mat-card
-            class="ride-card"
-            [class.selected]="selectedRide?.id === ride.id"
-            (click)="selectRide(ride)"
-          >
-            <mat-card-content>
-              <div class="ride-info">
-                <span class="time"
-                  >{{ ride.date.split(' ')[0] }} {{ ride.date.split(' ')[1] }}
-                  {{ ride.date.split(' ')[2] }}, {{ ride.startTime }} - {{ ride.endTime }}</span
-                >
-                <div class="route-wrapper">
-                  <mat-icon>location_on</mat-icon>
-                  <span class="route">{{ ride.from }} → {{ ride.to }}</span>
-                </div>
-              </div>
-              <div class="ride-meta">
-                <span class="price">{{ ride.price }} RSD</span>
-                <span class="status" [class]="'status-' + ride.status.toLowerCase()">
-                  {{ ride.status }}
-                </span>
-              </div>
-            </mat-card-content>
-          </mat-card>
-        }
+  <mat-card
+    class="ride-card"
+    [class.selected]="selectedRide?.id === ride.id"
+    (click)="selectRide(ride)"
+  >
+    <mat-card-content>
+      <div class="ride-info">
+        <span class="time"
+          >{{ ride.date.split(' ')[0] }} {{ ride.date.split(' ')[1] }}
+          {{ ride.date.split(' ')[2] }}, {{ ride.startTime }} - {{ ride.endTime }}</span
+        >
+        <div class="route-wrapper">
+          <mat-icon>location_on</mat-icon>
+          <span class="route">{{ ride.from }} → {{ ride.to }}</span>
+        </div>
+      </div>
+      <div class="ride-meta">
+        <span class="price">{{ ride.price }} RSD</span>
+        <span class="status" [class]="'status-' + ride.status.toLowerCase()">
+          {{ ride.status }}
+        </span>
+        <!-- DODAJ ZVEZDICU -->
+        <button 
+          class="favorite-btn" 
+          (click)="toggleFavorite(ride, $event)"
+          [class.favorite-active]="ride.isFavorite"
+        >
+          <mat-icon>{{ ride.isFavorite ? 'star' : 'star_border' }}</mat-icon>
+        </button>
+      </div>
+    </mat-card-content>
+  </mat-card>
+}
       }
     </div>
   </main>

--- a/IKS/src/app/rides/ride-history/user-ride-history/user-ride-history.ts
+++ b/IKS/src/app/rides/ride-history/user-ride-history/user-ride-history.ts
@@ -16,10 +16,12 @@ import { FormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { RateRideComponent } from '../../modals/rate-ride/rate-ride';
 import { RideService } from '../../services/ride.service';
+import { RouteService } from '../../../services/route.service'; // DODAJ
 import { AuthService } from '../../../services/auth.service';
 
 interface Ride {
   id: number;
+  routeId?: number; // DODAJ
   startTime: string;
   endTime: string;
   from: string;
@@ -31,6 +33,7 @@ interface Ride {
   distance?: string;
   driver?: { name: string; phone: string };
   vehicle?: { model: string; plate: string };
+  isFavorite?: boolean; // DODAJ
 }
 
 @Component({
@@ -68,6 +71,7 @@ export class UserRideHistory implements OnInit {
     private router: Router,
     private dialog: MatDialog,
     private rideService: RideService,
+    private routeService: RouteService, // DODAJ
     private authService: AuthService,
     private cdr: ChangeDetectorRef
   ) {}
@@ -83,8 +87,9 @@ export class UserRideHistory implements OnInit {
       next: (ridesFromBackend) => {
         this.allRides = ridesFromBackend.map(ride => ({
           id: ride.id,
-          date: ride.startTime?.split(',')[0]?.trim() || '-', // "04 Feb 2026"
-          startTime: ride.startTime?.split(',')[1]?.trim() || '-', // "21:20"
+          routeId: ride.routeId, // DODAJ
+          date: ride.startTime?.split(',')[0]?.trim() || '-',
+          startTime: ride.startTime?.split(',')[1]?.trim() || '-',
           endTime: ride.estimatedEndTime ? ride.estimatedEndTime.split(',')[1]?.trim() : '-',
           from: ride.startLocation || '-',
           to: ride.endLocation || '-',
@@ -98,8 +103,13 @@ export class UserRideHistory implements OnInit {
               : ride.driverEmail || '-',
             phone: ride.driverPhoneNumber || '-'
           },
-          vehicle: { model: '-', plate: '-' }
+          vehicle: { model: '-', plate: '-' },
+          isFavorite: false // DODAJ
         }));
+        
+        // Proveri koji su omiljeni
+        this.checkFavorites();
+        
         this.rides = [...this.allRides];
         this.selectedRide = this.rides.length > 0 ? this.rides[0] : null;
         this.cdr.detectChanges();
@@ -110,6 +120,58 @@ export class UserRideHistory implements OnInit {
     });
   }
 
+  // NOVA METODA
+  checkFavorites() {
+    this.allRides.forEach(ride => {
+      if (ride.routeId) {
+        this.routeService.isFavorite(ride.routeId).subscribe({
+          next: (isFav) => {
+            ride.isFavorite = isFav;
+            this.cdr.detectChanges();
+          },
+          error: (err) => console.error('Error checking favorite:', err)
+        });
+      }
+    });
+  }
+
+  // NOVA METODA
+  toggleFavorite(ride: Ride, event: Event) {
+    event.stopPropagation(); // Spreči selektovanje ride-a
+    
+    if (!ride.routeId) {
+      alert('Cannot add this ride to favorites (no route ID)');
+      return;
+    }
+
+    if (ride.isFavorite) {
+      // Ukloni iz omiljenih
+      this.routeService.removeFromFavorites(ride.routeId).subscribe({
+        next: () => {
+          ride.isFavorite = false;
+          this.cdr.detectChanges();
+        },
+        error: (err) => {
+          console.error('Error removing from favorites:', err);
+          alert('❌ Failed to remove from favorites');
+        }
+      });
+    } else {
+      // Dodaj u omiljene
+      this.routeService.addToFavorites(ride.routeId).subscribe({
+        next: () => {
+          ride.isFavorite = true;
+          this.cdr.detectChanges();
+        },
+        error: (err) => {
+          console.error('Error adding to favorites:', err);
+          alert('❌ Failed to add to favorites');
+        }
+      });
+    }
+  }
+
+  // OSTALE METODE OSTAJU ISTE...
   setActiveFilter(option: string) {
     this.activeFilter = option;
     
@@ -158,7 +220,6 @@ export class UserRideHistory implements OnInit {
   applyFilters() {
     let filtered = [...this.allRides];
     
-    // Filter by date range
     if (this.dateFrom || this.dateTo) {
       filtered = filtered.filter(ride => {
         const rideDate = this.parseRideDate(ride.date);
@@ -174,7 +235,6 @@ export class UserRideHistory implements OnInit {
       });
     }
     
-    // Filter by status
     if (this.selectedStatus) {
       filtered = filtered.filter(ride => 
         ride.status.toLowerCase() === this.selectedStatus.toLowerCase()
@@ -183,14 +243,12 @@ export class UserRideHistory implements OnInit {
     
     this.rides = filtered;
     
-    // Update selected ride if it's not in filtered results
     if (this.selectedRide && !this.rides.find(r => r.id === this.selectedRide?.id)) {
       this.selectedRide = this.rides.length > 0 ? this.rides[0] : null;
     }
   }
 
   parseRideDate(dateString: string): Date {
-    // Parse "04 Feb 2026" format (short and long month names)
     const months: { [key: string]: number } = {
       'Jan': 0, 'Feb': 1, 'Mar': 2, 'Apr': 3, 'May': 4, 'Jun': 5,
       'Jul': 6, 'Aug': 7, 'Sep': 8, 'Oct': 9, 'Nov': 10, 'Dec': 11,
@@ -276,8 +334,6 @@ export class UserRideHistory implements OnInit {
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
         console.log('Rating:', result.rating, result.comment);
-        // TODO: backend poziv
-        // this.ridesService.rateRide(ride.id, result)
       }
     });
   }

--- a/IKS/src/app/services/route.service.ts
+++ b/IKS/src/app/services/route.service.ts
@@ -2,20 +2,37 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+import { FavoriteRouteDTO } from '../models/ride-dto.model'; // DODAJ
 
 @Injectable({ providedIn: 'root' })
 export class RouteService {
-  private apiUrl = environment.apiUrl + '/route/estimate';
+  private apiUrl = environment.apiUrl + '/route';
 
   constructor(private http: HttpClient) {}
 
-  // Stari API (može se ukloniti kasnije)
+  // STARE METODE (ostaju iste)
   estimateRoute(pickup: string, destination: string): Observable<any> {
-    return this.http.post<any>(this.apiUrl, { pickup, destination });
+    return this.http.post<any>(`${this.apiUrl}/estimate`, { pickup, destination });
   }
 
-  // Novi API: šalje ceo DTO
   estimateRouteFull(request: any): Observable<any> {
-    return this.http.post<any>(this.apiUrl, request);
+    return this.http.post<any>(`${this.apiUrl}/estimate`, request);
+  }
+
+  // NOVE METODE - FAVORITES
+  addToFavorites(routeId: number): Observable<any> {
+    return this.http.post(`${this.apiUrl}/${routeId}/favorite`, {});
+  }
+
+  removeFromFavorites(routeId: number): Observable<any> {
+    return this.http.delete(`${this.apiUrl}/${routeId}/favorite`);
+  }
+
+  getFavoriteRoutes(): Observable<FavoriteRouteDTO[]> {
+    return this.http.get<FavoriteRouteDTO[]>(`${this.apiUrl}/favorites`);
+  }
+
+  isFavorite(routeId: number): Observable<boolean> {
+    return this.http.get<boolean>(`${this.apiUrl}/${routeId}/favorite/check`);
   }
 }

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/controller/RideController.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/controller/RideController.java
@@ -191,16 +191,6 @@ public class RideController {
         }
     }
 
-    // 2.4.3 Ordering from your favorite routes
-    @PostMapping("/favorites/{routeId}")
-    public ResponseEntity<RideHistoryDTO> createRideFromFavorite(@PathVariable Long routeId) {
-        RideHistoryDTO response = new RideHistoryDTO(
-                102, "me@example.com", "driver@example.com",
-                "Favorite Start", "Favorite End",
-                "ACCEPTED", 500.0, "2025-12-28T15:30:00");
-        return ResponseEntity.ok(response);
-    }
-
     // 2.6.1 The start of the ride
     @PutMapping("/{rideId}/start")
     @PreAuthorize("hasRole('DRIVER')")

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/controller/RouteController.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/controller/RouteController.java
@@ -3,11 +3,17 @@ package rs.ac.uns.ftn.asd.Projekatsiit2023.controller;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import rs.ac.uns.ftn.asd.Projekatsiit2023.dto.request.RideEstimationRequestDTO;
 import rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response.RideEstimationResponseDTO;
+import rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response.FavoriteRouteDTO;
+import rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response.AddToFavoritesResponseDTO;
 import rs.ac.uns.ftn.asd.Projekatsiit2023.service.RouteService;
+
+import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/route")
@@ -35,6 +41,67 @@ public class RouteController {
         RideEstimationResponseDTO response = getRideEstimationResponseDTO(request, estimation);
 
         return ResponseEntity.ok(response);
+    }
+
+    // Dodaj u omiljene
+    @PostMapping("/{routeId}/favorite")
+    @PreAuthorize("hasRole('REGISTERED_USER')")
+    public ResponseEntity<AddToFavoritesResponseDTO> addToFavorites(
+            @PathVariable Integer routeId,
+            Principal principal) {
+
+        if (principal == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        String userEmail = principal.getName();
+        AddToFavoritesResponseDTO response = routeService.addToFavorites(routeId, userEmail);
+        return ResponseEntity.ok(response);
+    }
+
+    // Ukloni iz omiljenih
+    @DeleteMapping("/{routeId}/favorite")
+    @PreAuthorize("hasRole('REGISTERED_USER')")
+    public ResponseEntity<AddToFavoritesResponseDTO> removeFromFavorites(
+            @PathVariable Integer routeId,
+            Principal principal) {
+
+        if (principal == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        String userEmail = principal.getName();
+        AddToFavoritesResponseDTO response = routeService.removeFromFavorites(routeId, userEmail);
+        return ResponseEntity.ok(response);
+    }
+
+    // Lista omiljenih ruta
+    @GetMapping("/favorites")
+    @PreAuthorize("hasRole('REGISTERED_USER')")
+    public ResponseEntity<List<FavoriteRouteDTO>> getFavoriteRoutes(Principal principal) {
+        if (principal == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        String userEmail = principal.getName();
+        List<FavoriteRouteDTO> favorites = routeService.getFavoriteRoutes(userEmail);
+        return ResponseEntity.ok(favorites);
+    }
+
+    // Proveri da li je ruta omiljena
+    @GetMapping("/{routeId}/favorite/check")
+    @PreAuthorize("hasRole('REGISTERED_USER')")
+    public ResponseEntity<Boolean> isFavorite(
+            @PathVariable Integer routeId,
+            Principal principal) {
+
+        if (principal == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        String userEmail = principal.getName();
+        boolean isFavorite = routeService.isRouteFavorite(routeId, userEmail);
+        return ResponseEntity.ok(isFavorite);
     }
 
     private static RideEstimationResponseDTO getRideEstimationResponseDTO(RideEstimationRequestDTO request, RouteService.RouteEstimation estimation) {

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/AddToFavoritesResponseDTO.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/AddToFavoritesResponseDTO.java
@@ -1,0 +1,16 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddToFavoritesResponseDTO {
+    private Integer routeId;
+    private String message;
+    private Boolean isFavorite;
+}

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/FavoriteRouteDTO.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/FavoriteRouteDTO.java
@@ -1,0 +1,21 @@
+package rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteRouteDTO {
+    private Integer routeId;
+    private String startLocation;
+    private String endLocation;
+    private List<String> intermediateStops;
+    private Double distanceKm;
+    private Double estimatedTimeMin;
+}

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/RideHistoryResponseDTO.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/dto/response/RideHistoryResponseDTO.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class RideHistoryResponseDTO {
     private Integer id;
+    private Integer routeId;
     private String passengerEmail;
     private String passengerFirstName;
     private String passengerLastName;

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/RideService.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/RideService.java
@@ -180,6 +180,7 @@ public class RideService {
 
             return new RideHistoryResponseDTO(
                     ride.getId(),
+                    ride.getRoute() != null ? ride.getRoute().getId() : null, // DODAJ OVO
                     ride.getPassenger().getEmail(),
                     ride.getPassenger().getFirstName(),
                     ride.getPassenger().getLastName(),
@@ -621,6 +622,7 @@ public class RideService {
 
             return new RideHistoryResponseDTO(
                     ride.getId(),
+                    ride.getRoute() != null ? ride.getRoute().getId() : null,
                     ride.getPassenger().getEmail(),
                     ride.getPassenger().getFirstName(),
                     ride.getPassenger().getLastName(),
@@ -715,6 +717,7 @@ public class RideService {
 
             return new RideHistoryResponseDTO(
                     ride.getId(),
+                    ride.getRoute() != null ? ride.getRoute().getId() : null, // DODAJ OVO
                     ride.getPassenger().getEmail(),
                     ride.getPassenger().getFirstName(),
                     ride.getPassenger().getLastName(),

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/RouteService.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/RouteService.java
@@ -13,6 +13,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rs.ac.uns.ftn.asd.Projekatsiit2023.model.Route;
 import rs.ac.uns.ftn.asd.Projekatsiit2023.repository.RouteRepository;
+import rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response.FavoriteRouteDTO;
+import rs.ac.uns.ftn.asd.Projekatsiit2023.dto.response.AddToFavoritesResponseDTO;
+import rs.ac.uns.ftn.asd.Projekatsiit2023.repository.RegisteredUserRepository;
+import rs.ac.uns.ftn.asd.Projekatsiit2023.model.RegisteredUser;
+import rs.ac.uns.ftn.asd.Projekatsiit2023.model.Location;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +38,8 @@ public class RouteService {
     public RouteService(RouteRepository routeRepository) {
         this.routeRepository = routeRepository;
     }
+    @Autowired
+    private RegisteredUserRepository userRepository;
 
     private final RestTemplate restTemplate = new RestTemplate();
 
@@ -110,5 +118,90 @@ public class RouteService {
             e.printStackTrace();
             return List.of();
         }
+    }
+
+    @Transactional
+    public AddToFavoritesResponseDTO addToFavorites(Integer routeId, String userEmail) {
+        RegisteredUser user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Route route = routeRepository.findById(routeId)
+                .orElseThrow(() -> new RuntimeException("Route not found"));
+
+        if (user.getFavoriteRoutes().contains(route)) {
+            return new AddToFavoritesResponseDTO(
+                    routeId,
+                    "Route is already in favorites",
+                    true
+            );
+        }
+
+        user.getFavoriteRoutes().add(route);
+        userRepository.save(user);
+
+        return new AddToFavoritesResponseDTO(
+                routeId,
+                "Route added to favorites",
+                true
+        );
+    }
+
+    @Transactional
+    public AddToFavoritesResponseDTO removeFromFavorites(Integer routeId, String userEmail) {
+        RegisteredUser user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Route route = routeRepository.findById(routeId)
+                .orElseThrow(() -> new RuntimeException("Route not found"));
+
+        user.getFavoriteRoutes().remove(route);
+        userRepository.save(user);
+
+        return new AddToFavoritesResponseDTO(
+                routeId,
+                "Route removed from favorites",
+                false
+        );
+    }
+
+    public List<FavoriteRouteDTO> getFavoriteRoutes(String userEmail) {
+        RegisteredUser user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return user.getFavoriteRoutes().stream()
+                .map(route -> {
+                    List<Location> locations = route.getLocations();
+
+                    if (locations == null || locations.isEmpty()) {
+                        return null;
+                    }
+
+                    String startLocation = locations.get(0).getAddress();
+                    String endLocation = locations.get(locations.size() - 1).getAddress();
+
+                    List<String> intermediateStops = locations.subList(1, locations.size() - 1)
+                            .stream()
+                            .map(Location::getAddress)
+                            .toList();
+
+                    return new FavoriteRouteDTO(
+                            route.getId(),
+                            startLocation,
+                            endLocation,
+                            intermediateStops,
+                            route.getDistance(),
+                            route.getEstimatedTime() / 60.0
+                    );
+                })
+                .filter(dto -> dto != null)
+                .toList();
+    }
+
+    public boolean isRouteFavorite(Integer routeId, String userEmail) {
+        RegisteredUser user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return user.getFavoriteRoutes().stream()
+                .anyMatch(route -> route.getId().equals(routeId));
     }
 }


### PR DESCRIPTION
Implemented favorite routes management system allowing users to save frequently used routes from their ride history via a star button and quickly reuse them when booking new rides. The booking form includes a "Select from Favorite Routes" section that dynamically loads saved routes from the database and auto-populates all location fields when selected, while still allowing users to modify any details before submitting. Favorites persist across sessions and all data is loaded dynamically with no hardcoded values.

For details, see issue #155.