### PR TITLE
[ISS] feat: add notifications and email for copassengers

### DIFF
--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/EmailService.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/EmailService.java
@@ -78,4 +78,51 @@ public class EmailService {
 
         mailSender.send(message);
     }
+
+    public void sendRideFinishedEmailToCoPassenger(String toEmail, Ride ride) {
+        String newRideLink = BASE_URL + "/book";
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject("Your Ride Has Been Completed – Thank You for Riding With Us");
+
+        String text = "Dear Customer,\n\n" +
+                "Your ride has been successfully completed.\n\n" +
+                "--------------- Ride Details ---------------\n" +
+                "From: " + ride.getStartLocation().getAddress() + "\n" +
+                "To: " + ride.getEndLocation().getAddress() + "\n" +
+                "Driver: " + ride.getDriver().getFirstName() + " " + ride.getDriver().getLastName() + "\n" +
+                "Price: " + String.format("%.2f", ride.getTotalPrice()) + " RSD\n" +
+                "-------------------------------------------\n\n" +
+                "Would you like to book your own ride? Visit:\n" +
+                newRideLink + "\n\n" +
+                "Kind regards,\nYour Support Team.";
+
+        message.setText(text);
+        mailSender.send(message);
+    }
+
+    public void sendRideAcceptedEmail(String toEmail, Ride ride) {
+        String trackLink = BASE_URL + "/track-ride/" + ride.getId();
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject("You've Been Added to a Ride – Track Your Journey");
+
+        String text = "Dear Customer,\n\n" +
+                "Great news! You have been added to a ride that has been successfully accepted.\n\n" +
+                "--------------- Ride Details ---------------\n" +
+                "From: " + ride.getStartLocation().getAddress() + "\n" +
+                "To: " + ride.getEndLocation().getAddress() + "\n" +
+                "Driver: " + ride.getDriver().getFirstName() + " " + ride.getDriver().getLastName() + "\n" +
+                "Vehicle: " + ride.getDriver().getVehicle().getModel() + "\n" +
+                "Scheduled: " + ride.getScheduledTime() + "\n" +
+                "-------------------------------------------\n\n" +
+                "You can track your ride in real time by clicking the link below:\n" +
+                trackLink + "\n\n" +
+                "Kind regards,\nYour Support Team.";
+
+        message.setText(text);
+        mailSender.send(message);
+    }
 }

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/NotificationService.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/NotificationService.java
@@ -43,6 +43,23 @@ public class NotificationService {
         }
     }
 
+    public void sendRideCoPassengerAddedNotification(RegisteredUser coPassenger, Ride ride) {
+        try {
+            Map<String, Object> payload = Map.of(
+                    "type", "RIDE_ACCEPTED",
+                    "rideId", ride.getId(),
+                    "message", "You've been added to a ride! Driver: " +
+                            ride.getDriver().getFirstName() + " " + ride.getDriver().getLastName(),
+                    "driverName", ride.getDriver().getFirstName() + " " + ride.getDriver().getLastName(),
+                    "vehicle", ride.getDriver().getVehicle().getModel()
+            );
+            String json = objectMapper.writeValueAsString(payload);
+            notificationHandler.sendToUser(coPassenger.getEmail(), json);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     public void sendRideAcceptedNotification(RegisteredUser passenger, Ride ride) {
         try {
             Map<String, Object> payload = Map.of(

--- a/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/RideService.java
+++ b/ISS/src/main/java/rs/ac/uns/ftn/asd/Projekatsiit2023/service/RideService.java
@@ -434,11 +434,19 @@ public class RideService {
         // Notifikacija putniku da je voznja prihvacena
         notificationService.sendRideAcceptedNotification(passenger, savedRide);
 
-// Notifikacija vozacu o novoj voznji
+        // Notifikacija vozacu o novoj voznji
         notificationService.sendRideDriverNotification(savedRide);
 
-// Podsjetnici 15, 10 i 5 minuta pre voznje
+        // Podsetnici 15, 10 i 5 minuta pre voznje
         scheduleRideReminders(savedRide, passenger.getEmail());
+
+        // Notifikacija i mejl ulinkovanih putnika
+        if (savedRide.getCoPassengers() != null) {
+            for (RegisteredUser coPassenger : savedRide.getCoPassengers()) {
+                notificationService.sendRideCoPassengerAddedNotification(coPassenger, savedRide);
+                emailService.sendRideAcceptedEmail(coPassenger.getEmail(), savedRide);
+            }
+        }
 
         return new RideCreatedResponseDTO(
                 savedRide.getId(),
@@ -1064,6 +1072,13 @@ public class RideService {
         Ride ride = rideRepository.findById(rideId).orElseThrow();
         notificationService.sendRideFinishedNotification(ride.getPassenger(), ride);
         emailService.sendRideFinishedEmail(ride.getPassenger().getEmail(), ride);
+
+        if (ride.getCoPassengers() != null) {
+            for (RegisteredUser coPassenger : ride.getCoPassengers()) {
+                notificationService.sendRideFinishedNotification(coPassenger, ride);
+                emailService.sendRideFinishedEmailToCoPassenger(coPassenger.getEmail(), ride);
+            }
+        }
 
         return response;
     }


### PR DESCRIPTION
## Description

This PR implements co-passenger ride notifications and emails. When a ride is successfully created and a driver is assigned, all linked co-passengers now receive a real-time WebSocket notification and an email with ride details and a direct link to the ride tracking page. When the ride is completed, co-passengers again receive a WebSocket notification and a tailored email without a rating link (only the main passenger can rate).

## Changes Made

- Added sendRideCoPassengerAddedNotification() in NotificationService — sends RIDE_ACCEPTED WebSocket notification with driver name and vehicle info to each co-passenger.
- Added loop in RideService.createNewRide() after existing notifications to send WebSocket notification and email to all co-passengers on ride creation.
- Added sendRideAcceptedEmail() (changed from private to accessible) and sendRideAcceptedEmailToCoPassenger() in EmailService — email includes ride details and /track-ride/{rideId} link.
- Added sendRideFinishedEmailToCoPassenger() in EmailService — tailored finished-ride email for co-passengers, without rating link.
- Updated RideService.endRideAndNotify() to loop through co-passengers and send both RIDE_FINISHED WebSocket notification and finished-ride email after transaction commits.

Closes #200